### PR TITLE
fixed 'unwatch is not a function' problem when trying to validate object's subitem

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,6 +65,7 @@ function install (Vue, options) {
 
       $validator._undefineValidatorToValidationScope(keypath, validator)
       $validator._deleteManagedValidator(keypath, validator)
+      $validator._undefineModelValidationScope(keypath)
 
       if (!$validator._isManagedValidator()) {
         for (var key in $validator.validation) {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -239,8 +239,10 @@ module.exports = {
 
     _unwatchModel: function (keypath) {
       var unwatch = this._validatorWatchers[keypath]
-      unwatch()
-      delete this._validatorWatchers[keypath]
+      if(unwatch) {
+        unwatch()
+        delete this._validatorWatchers[keypath]
+      }
     },
     
     _addManagedValidator: function (keypath, validator) {


### PR DESCRIPTION
fixed 'unwatch is not a function' problem when trying to validate object's subitem. for example  v-model="obj.item" v-validate="required" was causing error when trying to unwatch the element.
