### PR TITLE
Fix dead anchor tag

### DIFF
--- a/docs/en/syntax.md
+++ b/docs/en/syntax.md
@@ -33,7 +33,7 @@ v2.0-alpha later:
 ```
 
 ### Camel-case property
-As well as [Vue.js](http://vuejs.org/guide/components.html#camelCase_vs-_kebab-case), you can use the kebab-case for `v-validate` models:
+As well as [Vue.js](http://vuejs.org/guide/components.html#camelCase-vs-kebab-case), you can use the kebab-case for `v-validate` models:
 
 ```html
 <validator name="validation">


### PR DESCRIPTION
I found a dead anchor tag on this page: http://vuejs.github.io/vue-validator/en/syntax.html 

![image](https://cloud.githubusercontent.com/assets/1726225/15092525/80c33308-14a7-11e6-8160-6fd59b42d34f.png)
