### PR TITLE
Warning message text changes

### DIFF
--- a/dist/vue-validator.common.js
+++ b/dist/vue-validator.common.js
@@ -586,7 +586,7 @@ function Validate (Vue) {
 
       var validatorName = this.vm.$options._validator;
       if (process.env.NODE_ENV !== 'production' && !validatorName) {
-        warn('v-validate need to use into validator element directive: ' + '(e.g. <validator name="validator">' + '<input type="text" v-validate:field1="[\'required\']">' + '</validator>).');
+        warn('you need to wrap the elements to be validated in a <validator> element: ' + '(e.g. <validator name="validator">' + '<input type="text" v-validate:field1="[\'required\']">' + '</validator>).');
         this._invalid = true;
         return;
       }
@@ -2377,7 +2377,7 @@ function Validator (Vue) {
       var params = this.params;
 
       if (process.env.NODE_ENV !== 'production' && !params.name) {
-        warn('validator element directive need to specify \'name\' param attribute: ' + '(e.g. <validator name="validator1">...</validator>)');
+        warn('validator element requires a \'name\' attribute: ' + '(e.g. <validator name="validator1">...</validator>)');
         return;
       }
 

--- a/dist/vue-validator.js
+++ b/dist/vue-validator.js
@@ -590,7 +590,7 @@ var validators = Object.freeze({
 
         var validatorName = this.vm.$options._validator;
         if ('development' !== 'production' && !validatorName) {
-          warn('v-validate need to use into validator element directive: ' + '(e.g. <validator name="validator">' + '<input type="text" v-validate:field1="[\'required\']">' + '</validator>).');
+          warn('you need to wrap the elements to be validated in a <validator> element: ' + '(e.g. <validator name="validator">' + '<input type="text" v-validate:field1="[\'required\']">' + '</validator>).');
           this._invalid = true;
           return;
         }
@@ -2381,7 +2381,7 @@ var validators = Object.freeze({
         var params = this.params;
 
         if ('development' !== 'production' && !params.name) {
-          warn('validator element directive need to specify \'name\' param attribute: ' + '(e.g. <validator name="validator1">...</validator>)');
+          warn('validator element requires a \'name\' attribute: ' + '(e.g. <validator name="validator1">...</validator>)');
           return;
         }
 

--- a/docs/zh-cn/installation.md
+++ b/docs/zh-cn/installation.md
@@ -9,7 +9,7 @@
 ### jsdelivr
 
 ```html
-<script src="https://cdn.jsdelivr.net/vue.validator/2.0.2/vue-validator.min.js"></script>
+<script src="https://cdn.jsdelivr.net/vue.validator/2.1.1/vue-validator.min.js"></script>
 ```
 
 ## NPM

--- a/src/directives/validate.js
+++ b/src/directives/validate.js
@@ -79,7 +79,7 @@ export default function (Vue) {
 
       let validatorName = this.vm.$options._validator
       if ((process.env.NODE_ENV !== 'production') && !validatorName) {
-        warn('v-validate need to use into validator element directive: '
+        warn('you need to wrap the elements to be validated in a <validator> element: '
           + '(e.g. <validator name="validator">'
           + '<input type="text" v-validate:field1="[\'required\']">'
           + '</validator>).')

--- a/src/directives/validator.js
+++ b/src/directives/validator.js
@@ -22,7 +22,7 @@ export default function (Vue) {
       const params = this.params
 
       if (process.env.NODE_ENV !== 'production' && !params.name) {
-        warn('validator element directive need to specify \'name\' param attribute: '
+        warn('validator element requires a \'name\' attribute: '
             + '(e.g. <validator name="validator1">...</validator>)'
         )
         return


### PR DESCRIPTION
- Changed warning for when the elements under validation are not wrapped in a <validator> element.
- Changed warning for when the existing <validator> element does not have a name attribute.
