### PR TITLE
minor spelling correction - changed "build-in" to "built-in"

### DIFF
--- a/docs/en/SUMMARY.md
+++ b/docs/en/SUMMARY.md
@@ -8,7 +8,7 @@
 - [Getting started](started.md)
 - [Validation result structure](structure.md)
 - [Validator syntax](syntax.md)
-- [Build-in validators](validators.md)
+- [Built-in validators](validators.md)
 - [v-model integration](model.md)
 - [Reset validation results](reset.md)
 - [Form validatable elements](elements.md)

--- a/docs/en/validators.md
+++ b/docs/en/validators.md
@@ -1,6 +1,6 @@
-# Build-in validators
+# Built-in validators
 
-You can be used build-in validators of below:
+You can be used built-in validators of below:
 
 - `required`: whether the value has been specified
 - `pattern`: whether the pattern of the regular expression


### PR DESCRIPTION
Love the work so far on vue-validator and looking forward to using it in some of my upcoming projects.
This correction is a minor point but the usage here should be "built-in" not "build-in".
