### PR TITLE
`field`属性示例代码有误

### DIFF
--- a/docs/zh-cn/syntax.md
+++ b/docs/zh-cn/syntax.md
@@ -57,7 +57,7 @@ v2.0-alpha后:
     <form novalidate>
       <p class="validate-field" v-for="field in fields">
       <label :for="field.id">{{field.label}}</label>
-      <input type="text" :id="field.id" :placeholder="field.placeholder" field="{{field.name}}" v-validate="field.validate">
+      <input type="text" :id="field.id" :placeholder="field.placeholder" :field="{{field.name}}" v-validate="field.validate">
       </p>
       <pre>{{ $validation | json }}</pre>
     </form>


### PR DESCRIPTION
`field`属性应该带上`:`使用
