### PR TITLE
Changed some of the wording for validators.md

### DIFF
--- a/docs/en/validators.md
+++ b/docs/en/validators.md
@@ -1,12 +1,12 @@
 # Built-in validators
 
-You can be used built-in validators of below:
+You can use any of the built-in validators listed below:
 
 - `required`: whether the value has been specified
-- `pattern`: whether the pattern of the regular expression
-- `minlength`: whether the length of specified value is less than or equal minimum length
-- `maxlength`: whether the length of specified value is less more or equal maximum length
-- `min`: whether the specified numerical value is less than or equal minimum
-- `max`: whether the specified numerical value is more than or equal maximum
+- `pattern`: whether the value suffice the pattern of the regular expression
+- `minlength`: whether the length of the specified value is more than or equal to a minimum length
+- `maxlength`: whether the length of the specified value is less than or equal to a maximum length
+- `min`: whether the specified numerical value is more than or equal to a minimum
+- `max`: whether the specified numerical value is less than or equal to a maximum
 
 See more about [API section](/api.html#buildin-validators).


### PR DESCRIPTION
Fixed some grammatical mistakes and made documentation more clear by changing some words. Also I completely changed the meaning of things like "`min`: whether the specified numerical value is less than or equal to a minimum" because I believe there were some mistakes (I don't think a 'min' rules specifies that a value should be less than the minimum).
