### PR TITLE
Fixes the link to the "Issue Reporting Checklist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Please make sure to read the [Issue Reporting Checklist](https://github.com/vuej
 
 ## Contribution
 
-Please make sure to read the [Contributing Guide](https://github.com/vuejs/vue/blob/dev/CONTRIBUTING.md) before making a pull request.
+Please make sure to read the [Contributing Guide](https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md) before making a pull request.
 
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Validator component for Vue.js
 
 ## Issues
 
-Please make sure to read the [Issue Reporting Checklist](https://github.com/vuejs/vue/blob/dev/CONTRIBUTING.md#issue-reporting-guidelines) before opening an issue. Issues not conforming to the guidelines may be closed immediately.
+Please make sure to read the [Issue Reporting Checklist](https://github.com/vuejs/vue/blob/dev/.github/CONTRIBUTING.md#issue-reporting-guidelines) before opening an issue. Issues not conforming to the guidelines may be closed immediately.
 
 
 ## Contribution


### PR DESCRIPTION
I have adjusted another link the the README.md.
It's all good now :)

I don't know why my previous link will be shown. I've seen you've merged it already.
