### PR TITLE
Add jsDelivr hits badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CircleCI Status](https://circleci.com/gh/kazupon/vue-validator/tree/dev.svg?style=shield&circle-token=36fad1862fbb44da91a28217df8fba769d6d1ce7)](https://circleci.com/gh/kazupon/vue-validator/tree/dev)
 [![codecov](https://codecov.io/gh/kazupon/vue-validator/branch/dev/graph/badge.svg)](https://codecov.io/gh/kazupon/vue-validator)
 [![npm package](https://img.shields.io/npm/v/vue-validator.svg)](https://www.npmjs.com/package/vue-validator)
+[![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/vue-validator/badge?style=rounded)](https://www.jsdelivr.com/package/npm/vue-validator)
 
 Validator component for Vue.js
 


### PR DESCRIPTION
Hey, I noticed that vue-validator gets 324k hits per month on jsDelivr, so I thought you might like this badge. 